### PR TITLE
fix `prepareGraphQLPost` corner cases

### DIFF
--- a/circe/src/test/scala/sangria/http/akka/CirceGraphQLTest.scala
+++ b/circe/src/test/scala/sangria/http/akka/CirceGraphQLTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class CirceGraphQLTest extends AnyFlatSpec with GraphQLHttpSpec with GraphQLHttpSpecRoute {
   import TestData._
+
   private[this] final val path = s"/$graphQLPath"
 
   it should "handle an HTTP GET Request" in {
@@ -56,6 +57,13 @@ class CirceGraphQLTest extends AnyFlatSpec with GraphQLHttpSpec with GraphQLHttp
     Get(s"$path?operationName=Nope") ~> route ~> missingQueryCheck
     Post(path, emptyBody) ~> route ~> missingQueryCheck
     Post(path, emptyGraphQLQuery) ~> route ~> missingQueryCheck
+  }
+
+  it should "handle a POST request body without a query if the URI contains the query" in {
+    Post(s"$path?query=$query", emptyBody) ~> route ~> queryOnlyCheck
+    Post(s"$path?query=$query", emptyGraphQLQuery) ~> route ~> queryOnlyCheck
+
+    Post(s"$path?query=$query", bodyWithNameAndVariables) ~> route ~> namedQueryWithVariablesCheck
   }
 
   // TODO: Make this even better

--- a/circe/src/test/scala/sangria/http/akka/CirceGraphQLTest.scala
+++ b/circe/src/test/scala/sangria/http/akka/CirceGraphQLTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class CirceGraphQLTest extends AnyFlatSpec with GraphQLHttpSpec with GraphQLHttpSpecRoute {
   import TestData._
-  val path = s"/$graphQLPath"
+  private[this] final val path = s"/$graphQLPath"
 
   it should "handle an HTTP GET Request" in {
     Get(s"$path?query=$query") ~> route ~> queryOnlyCheck

--- a/circe/src/test/scala/sangria/http/akka/GraphQLHttpSpec.scala
+++ b/circe/src/test/scala/sangria/http/akka/GraphQLHttpSpec.scala
@@ -98,17 +98,30 @@ trait GraphQLHttpSpec extends AnyFlatSpec with ScalatestRouteTest with CirceHttp
   }
 }
 
+/** Provides a route for tests in this project. */
 trait GraphQLHttpSpecRoute extends CirceHttpSupport { this: Suite =>
   implicit def executor: ExecutionContext
 
+  /** The path, from the root, at which the service home resides. */
   val graphQLPath = "graphql"
-  val route: Route = {
 
+  /** A route for testing the service.
+    *
+    * The route simply completes with a string containing the arguments that were passed in:
+    * the query document, operation name, and variables.
+    * It parses the GraphQL request document, but doesn't execute it against a GraphQL server.
+    * This is sufficient for testing the Akka HTTP directives that this library provides.
+    */
+  val route: Route = {
     path(graphQLPath) {
       prepareGraphQLRequest {
-        // Yes, there is a `.get` here, and if this throws
-        // you have a far larger issue than this library.
-        // thank you for coming to my TED Talk.
+        /*FIXME The `source.get` below depends on `prepareGraphQLRequest` having quietly, internally, called
+         * `QueryParser.parse()` using the default `ParserConfig`, which uses the default `SourceMapper` function,
+         * which uses the `DefaultSourceMapper`, which creates a non-empty `source` member in the `SourceMapper`,
+         * which gets surfaced here through the `Document`.  Whew!
+         * Obviously this sort of magic shouldn't be buried inside `prepareGraphQLRequest`.  Part of this PR's goal
+         * is to surface that magic.
+         */
         case Success(req) => complete(s"""
                |[DOCUMENT]: ${Json.fromString(req.query.source.get).noSpacesSortKeys}
                |[OPERATION_NAME]: ${req.operationName}

--- a/circe/src/test/scala/sangria/http/akka/GraphQLHttpSpec.scala
+++ b/circe/src/test/scala/sangria/http/akka/GraphQLHttpSpec.scala
@@ -17,6 +17,7 @@ import scala.util.{Failure, Success}
 trait GraphQLHttpSpec extends AnyFlatSpec with ScalatestRouteTest with CirceHttpSupport {
   import TestData._
 
+  /** A response that contains only [[sampleQuery the sample query]]. */
   val queryOnly: String = s"""
                              |[DOCUMENT]: "$sampleQuery"
                              |[OPERATION_NAME]: None
@@ -37,6 +38,7 @@ trait GraphQLHttpSpec extends AnyFlatSpec with ScalatestRouteTest with CirceHttp
                                            |[OPERATION_NAME]: Some($sampleOperationName)
                                            |[VARIABLES]: ${sampleVariables.noSpacesSortKeys}""".stripMargin
 
+  /** Testkit check for [[queryOnly only a query in the response]]. */
   val queryOnlyCheck: RouteTestResult => Assertion = check {
     val resp = responseAs[String]
     assert(

--- a/circe/src/test/scala/sangria/http/akka/GraphQLHttpSpec.scala
+++ b/circe/src/test/scala/sangria/http/akka/GraphQLHttpSpec.scala
@@ -1,5 +1,8 @@
 package sangria.http.akka
 
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.RequestEntity
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
@@ -11,11 +14,18 @@ import sangria.parser.SyntaxError
 import sangria.http.akka.SangriaAkkaHttp._
 import sangria.http.akka.circe.CirceHttpSupport
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
 import scala.util.{Failure, Success}
 
 trait GraphQLHttpSpec extends AnyFlatSpec with ScalatestRouteTest with CirceHttpSupport {
   import TestData._
+
+  /** Request entity with a weird content type. */
+  protected val weirdEntity: RequestEntity =
+    Await.result(Marshal(bodyQueryOnly).to[RequestEntity], 1.second)
+      .withContentType(`application/octet-stream`)
+
 
   /** A response that contains only [[sampleQuery the sample query]]. */
   val queryOnly: String = s"""

--- a/circe/src/test/scala/sangria/http/akka/TestData.scala
+++ b/circe/src/test/scala/sangria/http/akka/TestData.scala
@@ -22,17 +22,24 @@ object TestData {
   )
 
   /* JSON Payloads */
+  /** JSON GraphQL object with only a `query` field. */
   val bodyQueryOnly: Json = Json.obj(
     "query" -> Json.fromString(sampleQuery)
   )
+
+  /** JSON GraphQL object with `query` and `operationName` fields. */
   val bodyNamedQuery: Json = Json.obj(
     "query" -> Json.fromString(sampleQuery),
     "operationName" -> Json.fromString(sampleOperationName)
   )
+
+  /** JSON GraphQL object with `query` and `variables` fields. */
   val bodyWithVariables: Json = Json.obj(
     "query" -> Json.fromString(sampleQuery),
     "variables" -> sampleVariables
   )
+
+  /** JSON GraphQL object with `query`, `operationName` and `variables` fields. */
   val bodyNamedQueryWithVariables: Json = Json.obj(
     "query" -> Json.fromString(sampleQuery),
     "operationName" -> Json.fromString(sampleOperationName),

--- a/circe/src/test/scala/sangria/http/akka/TestData.scala
+++ b/circe/src/test/scala/sangria/http/akka/TestData.scala
@@ -4,7 +4,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import akka.http.scaladsl.model.ContentTypes
-import akka.http.scaladsl.model.{HttpEntity}
+import akka.http.scaladsl.model.HttpEntity
 import io.circe.Json
 
 object TestData {
@@ -45,13 +45,13 @@ object TestData {
   val variables: String = URLEncoder.encode(sampleVariables.toString, UTF_8)
 
   /* application/graphql entity */
-  val queryAsGraphQL = HttpEntity(string = sampleQuery, contentType = `application/graphql`)
+  val queryAsGraphQL: HttpEntity.Strict = HttpEntity(string = sampleQuery, contentType = `application/graphql`)
 
   /* Malformed Data */
   private val malformedQuery = "query Nope { fieldBad "
   val malformedQueryString: String = URLEncoder.encode(malformedQuery, UTF_8)
   val emptyBody: Json = Json.obj()
-  val malformedJsonQuery = Json.obj(
+  val malformedJsonQuery: Json = Json.obj(
     "query" -> Json.fromString(malformedQuery)
   )
 

--- a/circe/src/test/scala/sangria/http/akka/TestData.scala
+++ b/circe/src/test/scala/sangria/http/akka/TestData.scala
@@ -10,6 +10,7 @@ import io.circe.Json
 object TestData {
   import GraphQLRequestUnmarshaller.`application/graphql`
 
+  /** A GraphQL query request having a single, named operation. */
   val sampleQuery = "query TestQuery { fieldName }"
   val sampleOperationName = "TestQuery"
   val sampleVariables: Json = Json.obj(
@@ -38,6 +39,12 @@ object TestData {
     "variables" -> sampleVariables
   )
 
+  /** JSON GraphQL request object having `operationName` and `variables` but no `query`. */
+  val bodyWithNameAndVariables: Json = Json.obj(
+    "operationName" -> Json.fromString(sampleOperationName),
+    "variables" -> sampleVariables
+  )
+
   /* QueryString Parameters */
   private val UTF_8: String = StandardCharsets.UTF_8.toString
   val query: String = URLEncoder.encode(sampleQuery, UTF_8)
@@ -47,14 +54,19 @@ object TestData {
   /* application/graphql entity */
   val queryAsGraphQL: HttpEntity.Strict = HttpEntity(string = sampleQuery, contentType = `application/graphql`)
 
-  /* Malformed Data */
-  private val malformedQuery = "query Nope { fieldBad "
+  /** An invalid GraphQL request. */
+  private[this] final val malformedQuery = "query Nope { fieldBad "
+
+  /** An URL-encoded, [[malformedQuery invalid GraphQL request]] (for use in a URI). */
   val malformedQueryString: String = URLEncoder.encode(malformedQuery, UTF_8)
+
+  /** An empty JSON object. */
   val emptyBody: Json = Json.obj()
   val malformedJsonQuery: Json = Json.obj(
     "query" -> Json.fromString(malformedQuery)
   )
 
+  /** HTTP entity having JSON content type but containing invalid JSON. */
   val badJson: HttpEntity.Strict =
     HttpEntity(
       string = s"""{
@@ -68,6 +80,7 @@ object TestData {
   val malformedGraphQLQuery: HttpEntity.Strict =
     HttpEntity(string = malformedQuery, contentType = `application/graphql`)
 
+  /** HTTP entity having GraphQL content type but empty content. */
   val emptyGraphQLQuery: HttpEntity.Strict =
     HttpEntity(string = "", contentType = `application/graphql`)
 }

--- a/core/src/main/scala/sangria/http/akka/GraphQLHttpRequest.scala
+++ b/core/src/main/scala/sangria/http/akka/GraphQLHttpRequest.scala
@@ -1,6 +1,18 @@
 package sangria.http.akka
 
-case class GraphQLHttpRequest[T](
-    query: Option[String],
-    variables: Option[T],
-    operationName: Option[String])
+/** A GraphQL request via an HTTP POST.
+  *
+  * @param query
+  *   A [[https://spec.graphql.org/June2018/#Document GraphQL Document]].
+  *   A Document must be present either here, or in the URI query parameter of the POST
+  *   (in which case it's optional here and will be overridden if present).
+  * @param operationName
+  *   The name of the Operation in the Document to execute.
+  *   [[https://spec.graphql.org/June2018/#sec-Executing-Requests Required if the Document contains
+  *   more than one operation.]]
+  * @param variables Values for any Variables defined by the Operation.
+  *
+  * @see https://spec.graphql.org/June2018/#sec-Execution
+  * @see https://graphql.org/learn/serving-over-http/#post-request
+  */
+case class GraphQLHttpRequest[T](query: Option[String], variables: Option[T], operationName: Option[String])

--- a/core/src/main/scala/sangria/http/akka/GraphQLHttpRequest.scala
+++ b/core/src/main/scala/sangria/http/akka/GraphQLHttpRequest.scala
@@ -8,8 +8,7 @@ package sangria.http.akka
   *   (in which case it's optional here and will be overridden if present).
   * @param operationName
   *   The name of the Operation in the Document to execute.
-  *   [[https://spec.graphql.org/June2018/#sec-Executing-Requests Required if the Document contains
-  *   more than one operation.]]
+  *   [[https://spec.graphql.org/June2018/#sec-Executing-Requests Required if the Document contains more than one operation.]]
   * @param variables Values for any Variables defined by the Operation.
   *
   * @see https://spec.graphql.org/June2018/#sec-Execution

--- a/core/src/main/scala/sangria/http/akka/GraphQLRequestUnmarshaller.scala
+++ b/core/src/main/scala/sangria/http/akka/GraphQLRequestUnmarshaller.scala
@@ -13,16 +13,13 @@ import sangria.renderer.{QueryRenderer, QueryRendererConfig}
 import scala.collection.immutable.Seq
 
 object GraphQLRequestUnmarshaller {
-  val `application/graphql` =
+  val `application/graphql`: MediaType.WithFixedCharset =
     MediaType.applicationWithFixedCharset("graphql", HttpCharsets.`UTF-8`, "graphql")
 
-  def unmarshallerContentTypes: Seq[ContentTypeRange] =
-    mediaTypes.map(ContentTypeRange.apply)
+  val mediaTypes: Seq[MediaType.WithFixedCharset] = List(`application/graphql`)
+  val unmarshallerContentTypes: Seq[ContentTypeRange] = mediaTypes.map(ContentTypeRange.apply)
 
-  def mediaTypes: Seq[MediaType.WithFixedCharset] =
-    List(`application/graphql`)
-
-  implicit final def documentMarshaller(implicit
+  implicit def documentMarshaller(implicit
       config: QueryRendererConfig = QueryRenderer.Compact): ToEntityMarshaller[Document] =
     Marshaller.oneOf(mediaTypes: _*) { mediaType =>
       Marshaller.withFixedContentType(ContentType(mediaType)) { json =>
@@ -30,7 +27,7 @@ object GraphQLRequestUnmarshaller {
       }
     }
 
-  implicit final val documentUnmarshaller: FromEntityUnmarshaller[Document] =
+  implicit val documentUnmarshaller: FromEntityUnmarshaller[Document] =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(unmarshallerContentTypes: _*)
       .map {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.5.5


### PR DESCRIPTION
- [ ] ~~Make the `GraphQLHttpRequest` `query` field non-optional, as implied by [the informal spec](https://graphql.org/learn/serving-over-http/#post-request).~~
- [x] Utilize the URI `query` parameter in a POST. In fact, it should override any query in the message body. This seems to be the intention of [the informal spec](https://graphql.org/learn/serving-over-http/#post-request).
- [x] Silently ignore the `operationName` and `variables` URI query parameters that the code is currently accepting in a POST, in order to be more in line with [the informal spec](https://graphql.org/learn/serving-over-http/#post-request).
- [x] Don't attempt to parse the HTTP message body unless the `Content-Type` is one of the allowed `application/json` or `application/graphql`, and then parse for the respective type. In particular, a missing content type should not be accepted, and other content types should not be parsed (as they currently are, treated as `application/graphql`).
- [ ] Rewrite `prepareGraphQLPost` as an Akka HTTP `Directive`.
- [ ] In error responses, return a `data: null` field when execution has started.

Solves #13.

### content type

The existing tests _do_ create the `application/json` content type as a side-effect of the entity creation by the JSON marshaler. And the existing code _does_ look for that content type as a side-effect of unmarshaling JSON.

The existing tests _do_ explicitly create an `application/graphql` entity. **But** the existing code does not appear to look for that content type before parsing it.